### PR TITLE
チーム情報の操作に関しての機能を整えること

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,8 +30,11 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
+    elsif current_user != assign.team.owner && current_user != assign.user
+      I18n.t('views.messages.not_authorized')
     elsif assign.destroy
-      set_next_team(assign, assigned_user)
+      another_team = Assign.find_by(user_id: assigned_user.id).team
+      change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
       I18n.t('views.messages.delete_member')
     else
       I18n.t('views.messages.cannot_delete_member_4_some_reason')
@@ -40,10 +43,5 @@ class AssignsController < ApplicationController
   
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
-  end
-  
-  def set_next_team(assign, assigned_user)
-    another_team = Assign.find_by(user_id: assigned_user.id).team
-    change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    unless current_user == @team.owner
+      redirect_to team_path, notice: I18n.t('views.messages.not_authorized')
+    end
+  end
 
   def create
     @team = Team.new(team_params)

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -14,7 +14,9 @@
       <tr>
         <td><%= team.name %></td>
         <td><%= link_to 'Show', team %></td>
-        <td><%= link_to 'Edit', edit_team_path(team) %></td>
+        <% if current_user == team.owner %>
+          <td><%= link_to 'Edit', edit_team_path(team) %></td>
+        <% end %>
         <td><%= link_to 'Destroy', team, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user == @team.owner %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>  
           </div>
 
           <div class="col-md-8">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,7 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      not_authorized: '権限がありません'
     button:
       submit: '投稿'
       edit: '編集'


### PR DESCRIPTION
#5 

- Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできない仕様に変更

- TeamのeditはTeamのリーダー（オーナー）のみができる仕様に変更